### PR TITLE
Adjusted the permissions perfix from "supernaturals" to "automessage"

### DIFF
--- a/src/main/java/com/TeamNovus/AutoMessage/Permission.java
+++ b/src/main/java/com/TeamNovus/AutoMessage/Permission.java
@@ -29,7 +29,7 @@ public enum Permission {
 	}
 	
 	private static String getPermission(Permission permission) {
-		return "supernaturals." + permission.getNode();
+		return "automessage." + permission.getNode();
 	}
 	
 	public static Boolean has(Permission permission, CommandSender target) {


### PR DESCRIPTION
This likley got into the codebase when the permissions code from supernaturals was copied over.

Signed-off-by: Aaron Haun kj4ips@antichthon.net
